### PR TITLE
fix: support non-string environment values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 Changelog
 =========
 
-## v0.3.0
+## v0.3.1
 (Thanks to Julian Scheid)
 - Add support for additional types of environment variables for a service
+
+## v0.3.0
+(Thanks to Julian Scheid)
+- support for latest build settings
 
 ## v0.2.5
 - Update outdated dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## v0.3.0
+(Thanks to Julian Scheid)
+- Add support for additional types of environment variables for a service
+
 ## v0.2.5
 - Update outdated dependencies
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docker-compose-types"
 description = "Deserialization and Serialization of docker-compose.yml files in a relatively strongly typed fashion."
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 repository = "https://github.com/stephanbuys/docker-compose-types"
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docker-compose-types"
 description = "Deserialization and Serialization of docker-compose.yml files in a relatively strongly typed fashion."
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 repository = "https://github.com/stephanbuys/docker-compose-types"
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,6 +298,24 @@ pub struct AdvancedBuildStep {
     pub args: Option<BuildArgs>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shm_size: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_from: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<BuildLabels>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum BuildLabels {
+    List(Vec<String>),
+    #[cfg(feature = "indexmap")]
+    KvPair(IndexMap<String, Option<String>>),
+    #[cfg(not(feature = "indexmap"))]
+    KvPair(HashMap<String, Option<String>>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,14 +190,14 @@ pub struct LoggingParameterOptions {
     pub max_size: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum Environment {
     List(Vec<String>),
     #[cfg(feature = "indexmap")]
-    KvPair(IndexMap<String, Option<String>>),
+    KvPair(IndexMap<String, Option<EnvTypes>>),
     #[cfg(not(feature = "indexmap"))]
-    KvPair(HashMap<String, Option<String>>),
+    KvPair(HashMap<String, Option<EnvTypes>>),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Hash)]
@@ -205,6 +205,8 @@ pub enum Environment {
 pub enum EnvTypes {
     String(String),
     Number(serde_yaml::Number),
+    Bool(bool),
+    Null,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Default, Ord, PartialOrd)]

--- a/tests/fixtures/build-args/docker-compose.yml
+++ b/tests/fixtures/build-args/docker-compose.yml
@@ -1,7 +1,16 @@
-version: '2.2'
+version: "3.4"
 services:
   web:
     build:
       context: .
       args:
         - favorite_th_character=mariya.kirisame
+      target: prod
+      network: host
+      cache_from:
+        - alpine:latest
+        - corp/web_app:3.14
+      labels:
+        com.example.description: "Accounting webapp"
+        com.example.department: "Finance"
+        com.example.label-with-empty-value: ""

--- a/tests/fixtures/environment-composefile/docker-compose.yml
+++ b/tests/fixtures/environment-composefile/docker-compose.yml
@@ -7,3 +7,7 @@ services:
     environment:
       foo: bar
       hello: world
+      bool: true
+      integer: 123
+      float: 123.456
+      zilch: null


### PR DESCRIPTION
I can't find this behavior documented, specced, or tested anywhere around the Compose code, and paging through the Go code (I'm not very familiar with Go) I can't immediately see how this works. My best uneducated guess is that whatever lib they're using to deserialize YAML into `MappingWithEquals` silently translates some types into strings.

That said...
- As mentioned in #15, compose will happily accept these other types and interpolate them.
- I've managed to pry an interesting error message out of 20.10.20 by giving `[]` as a value: `services.test.environment.test must be a string, number, boolean or null`.
- It's not terribly hard to find in the wild, for example [this](https://github.com/Oleg339/IntershipInnowize/blob/098fa7a52f1c5da2e22275ba06a9635b18ee88d2/docker-compose.yml#L38) is from page 3 when searching for `filename:dockerfile-compose.yml` on GitHub.

I've reused the `EnvTypes` type because it's not used anywhere else and looks like it was intended for this purpose?

I've decided to keep `Null` separate from `None` (empty YAML mapping), I figured even if it looks like compose is treating the two the same, better have too much information and throw it away when you don't need it.

I think there's a similar issue with `args` but I'll leave that for another time. It's not exactly the same issue because unlike `environment`, `args` seems happy to accept `[]` as a value.
