### PR TITLE
Add missing properties and some refactoring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,8 @@ pub struct Service {
     pub tty: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sysctls: Option<SysCtls>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security_opt: Option<Vec<String>>,
 }
 
 impl Service {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,20 +192,10 @@ pub struct LoggingParameters {
     pub driver: String,
     #[cfg(feature = "indexmap")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub options: Option<IndexMap<String, LoggingOptionValue>>,
+    pub options: Option<IndexMap<String, SingleValue>>,
     #[cfg(not(feature = "indexmap"))]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub options: Option<HashMap<String, LoggingOptionValue>>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum LoggingOptionValue {
-    String(String),
-    Bool(bool),
-    Unsigned(u64),
-    Signed(i64),
-    Float(f64),
+    pub options: Option<HashMap<String, SingleValue>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -213,18 +203,9 @@ pub enum LoggingOptionValue {
 pub enum Environment {
     List(Vec<String>),
     #[cfg(feature = "indexmap")]
-    KvPair(IndexMap<String, Option<EnvTypes>>),
+    KvPair(IndexMap<String, Option<SingleValue>>),
     #[cfg(not(feature = "indexmap"))]
-    KvPair(HashMap<String, Option<EnvTypes>>),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Hash)]
-#[serde(untagged)]
-pub enum EnvTypes {
-    String(String),
-    Number(serde_yaml::Number),
-    Bool(bool),
-    Null,
+    KvPair(HashMap<String, Option<SingleValue>>),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Default, Ord, PartialOrd)]
@@ -380,33 +361,9 @@ pub struct AdvancedNetworkSettings {
 pub enum SysCtls {
     List(Vec<String>),
     #[cfg(feature = "indexmap")]
-    Map(IndexMap<String, SysCtlValue>),
+    Map(IndexMap<String, Option<SingleValue>>),
     #[cfg(not(feature = "indexmap"))]
-    Map(HashMap<String, SysCtlValue>),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum SysCtlValue {
-    Null,
-    String(String),
-    Bool(bool),
-    Unsigned(u64),
-    Signed(i64),
-    Float(f64),
-}
-
-impl fmt::Display for SysCtlValue {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Null => f.write_str("null"),
-            Self::String(s) => f.write_str(s),
-            Self::Bool(b) => write!(f, "{b}"),
-            Self::Unsigned(u) => write!(f, "{u}"),
-            Self::Signed(i) => write!(f, "{i}"),
-            Self::Float(fl) => write!(f, "{fl}"),
-        }
-    }
+    Map(HashMap<String, Option<SingleValue>>),
 }
 
 #[cfg(feature = "indexmap")]
@@ -651,6 +608,28 @@ pub enum Command {
 pub enum Entrypoint {
     Simple(String),
     List(Vec<String>),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd)]
+#[serde(untagged)]
+pub enum SingleValue {
+    String(String),
+    Bool(bool),
+    Unsigned(u64),
+    Signed(i64),
+    Float(f64),
+}
+
+impl fmt::Display for SingleValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::String(s) => f.write_str(s),
+            Self::Bool(b) => write!(f, "{b}"),
+            Self::Unsigned(u) => write!(f, "{u}"),
+            Self::Signed(i) => write!(f, "{i}"),
+            Self::Float(fl) => write!(f, "{fl}"),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -814,6 +814,15 @@ impl<T> Default for MapOrEmpty<T> {
     }
 }
 
+impl<T> From<MapOrEmpty<T>> for Option<T> {
+    fn from(value: MapOrEmpty<T>) -> Self {
+        match value {
+            MapOrEmpty::Map(t) => Some(t),
+            MapOrEmpty::Empty => None,
+        }
+    }
+}
+
 impl<T> Serialize for MapOrEmpty<T>
 where
     T: Serialize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,6 @@ pub struct Service {
     pub extra_hosts: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tty: Option<bool>,
-
 }
 
 impl Service {
@@ -346,7 +345,9 @@ pub struct AdvancedNetworks(pub HashMap<String, Option<AdvancedNetworkSettings>>
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
 #[serde(deny_unknown_fields)]
 pub struct AdvancedNetworkSettings {
-    pub ipv4_address: String,
+    pub ipv4_address: Option<String>,
+    pub ipv6_address: Option<String>,
+    pub aliases: Option<Vec<String>>,
 }
 
 #[cfg(feature = "indexmap")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,8 @@ pub struct Service {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Labels>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub tmpfs: Option<Tmpfs>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ulimits: Option<Ulimits>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub volumes: Option<Volumes>,
@@ -265,6 +267,13 @@ pub struct Labels(pub IndexMap<String, String>);
 #[cfg(not(feature = "indexmap"))]
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Labels(pub HashMap<String, String>);
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum Tmpfs {
+    Simple(String),
+    List(Vec<String>),
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
 #[serde(deny_unknown_fields)]
@@ -565,13 +574,29 @@ pub struct AdvancedVolumes {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub read_only: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bind: Option<Bind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub volume: Option<Volume>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tmpfs: Option<TmpfsSettings>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Bind {
+    pub propagation: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Volume {
     pub nocopy: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Default)]
+#[serde(deny_unknown_fields)]
+pub struct TmpfsSettings {
+    pub size: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,17 +187,25 @@ pub struct DependsCondition {
     pub condition: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct LoggingParameters {
     pub driver: String,
+    #[cfg(feature = "indexmap")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub options: Option<LoggingParameterOptions>,
+    pub options: Option<IndexMap<String, LoggingOptionValue>>,
+    #[cfg(not(feature = "indexmap"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<HashMap<String, LoggingOptionValue>>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
-pub struct LoggingParameterOptions {
-    #[serde(rename = "max-size")]
-    pub max_size: String,
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum LoggingOptionValue {
+    String(String),
+    Bool(bool),
+    Unsigned(u64),
+    Signed(i64),
+    Float(f64),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,8 +77,8 @@ pub struct Service {
     pub environment: Option<Environment>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_mode: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub devices: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub devices: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub restart: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -91,8 +91,8 @@ pub struct Service {
     pub volumes: Option<Volumes>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub networks: Option<Networks>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cap_add: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cap_add: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub depends_on: Option<DependsOnOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -103,12 +103,12 @@ pub struct Service {
     pub env_file: Option<EnvFile>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_grace_period: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub profiles: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub dns: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub profiles: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dns: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipc: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -145,14 +145,14 @@ pub struct Service {
     #[cfg(not(feature = "indexmap"))]
     #[serde(flatten, skip_serializing_if = "HashMap::is_empty")]
     pub extensions: HashMap<Extension, Value>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub extra_hosts: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_hosts: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tty: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sysctls: Option<SysCtls>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub security_opt: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub security_opt: Vec<String>,
 }
 
 impl Service {
@@ -353,8 +353,8 @@ pub struct AdvancedBuildStep {
     pub target: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub network: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cache_from: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cache_from: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub labels: Option<Labels>,
 }
@@ -384,8 +384,8 @@ pub struct AdvancedNetworkSettings {
     pub ipv4_address: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipv6_address: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub aliases: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -501,8 +501,8 @@ pub struct Deploy {
     pub mode: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replicas: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub labels: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub update_config: Option<UpdateConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,9 +225,12 @@ pub struct Port {
     pub target: u16,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub host_ip: Option<String>,
-    pub published: PublishedPort,
-    pub protocol: String,
-    pub mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub published: Option<PublishedPort>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -415,12 +418,19 @@ pub struct ComposeVolume {
     #[cfg(not(feature = "indexmap"))]
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub driver_opts: HashMap<String, Option<SingleValue>>,
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub external: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external: Option<ExternalVolume>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Labels>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum ExternalVolume {
+    Bool(bool),
+    Name { name: String },
 }
 
 #[cfg(feature = "indexmap")]
@@ -488,6 +498,8 @@ pub struct Ipam {
 #[serde(deny_unknown_fields)]
 pub struct IpamConfig {
     pub subnet: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gateway: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,12 +254,15 @@ pub struct Services(pub IndexMap<String, Option<Service>>);
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Services(pub HashMap<String, Option<Service>>);
 
-#[cfg(feature = "indexmap")]
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct Labels(pub IndexMap<String, String>);
-#[cfg(not(feature = "indexmap"))]
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct Labels(pub HashMap<String, String>);
+#[serde(untagged)]
+pub enum Labels {
+    List(Vec<String>),
+    #[cfg(feature = "indexmap")]
+    Map(IndexMap<String, String>),
+    #[cfg(not(feature = "indexmap"))]
+    Map(HashMap<String, String>),
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(untagged)]
@@ -314,17 +317,7 @@ pub struct AdvancedBuildStep {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_from: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub labels: Option<BuildLabels>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-#[serde(untagged)]
-pub enum BuildLabels {
-    List(Vec<String>),
-    #[cfg(feature = "indexmap")]
-    KvPair(IndexMap<String, Option<String>>),
-    #[cfg(not(feature = "indexmap"))]
-    KvPair(HashMap<String, Option<String>>),
+    pub labels: Option<Labels>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,32 +399,28 @@ pub enum SysCtls {
 }
 
 #[cfg(feature = "indexmap")]
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct ComposeVolumes(pub IndexMap<String, Option<IndexMap<String, String>>>);
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct TopLevelVolumes(IndexMap<String, MapOrEmpty<ComposeVolume>>);
 #[cfg(not(feature = "indexmap"))]
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct ComposeVolumes(pub HashMap<String, Option<HashMap<String, String>>>);
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct TopLevelVolumes(HashMap<String, MapOrEmpty<ComposeVolume>>);
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-#[serde(untagged)]
-pub enum TopLevelVolumes {
-    CV(ComposeVolumes),
-    Labelled(LabelledComposeVolumes),
-}
-
-#[cfg(feature = "indexmap")]
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct LabelledComposeVolumes(pub IndexMap<String, VolumeLabels>);
-#[cfg(not(feature = "indexmap"))]
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct LabelledComposeVolumes(pub HashMap<String, VolumeLabels>);
-
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct VolumeLabels {
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ComposeVolume {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub driver: Option<String>,
     #[cfg(feature = "indexmap")]
-    pub labels: IndexMap<String, String>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub driver_opts: IndexMap<String, Option<SingleValue>>,
     #[cfg(not(feature = "indexmap"))]
-    pub labels: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub driver_opts: HashMap<String, Option<SingleValue>>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub external: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<Labels>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 
 #[cfg(feature = "indexmap")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,11 +396,11 @@ pub struct VolumeLabels {
 }
 
 #[cfg(feature = "indexmap")]
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ComposeNetworks(pub IndexMap<String, MapOrEmpty<NetworkSettings>>);
 
 #[cfg(not(feature = "indexmap"))]
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ComposeNetworks(pub HashMap<String, MapOrEmpty<NetworkSettings>>);
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
@@ -420,24 +420,39 @@ pub struct ComposeNetworkSettingDetails {
 #[serde(deny_unknown_fields)]
 pub struct ExternalNetworkSettingBool(bool);
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct NetworkSettings {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub attachable: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub driver: Option<String>,
+    #[cfg(feature = "indexmap")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub internal: Option<ComposeNetwork>,
+    pub driver_opts: Option<IndexMap<String, Option<SingleValue>>>,
+    #[cfg(not(feature = "indexmap"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub driver_opts: Option<HashMap<String, Option<SingleValue>>>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub enable_ipv6: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub internal: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external: Option<ComposeNetwork>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipam: Option<Ipam>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<Labels>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
 #[serde(deny_unknown_fields)]
 pub struct Ipam {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub driver: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub config: Vec<IpamConfig>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,17 +277,18 @@ pub enum Tmpfs {
     List(Vec<String>),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
-#[serde(deny_unknown_fields)]
-pub struct Ulimits {
-    pub nofile: Nofile,
-}
+#[cfg(feature = "indexmap")]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Ulimits(pub IndexMap<String, Ulimit>);
+#[cfg(not(feature = "indexmap"))]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Ulimits(pub HashMap<String, Ulimit>);
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
-#[serde(deny_unknown_fields)]
-pub struct Nofile {
-    pub soft: i64,
-    pub hard: i64,
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum Ulimit {
+    Single(i64),
+    SoftHard { soft: i64, hard: i64 },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,8 @@ pub struct Service {
     pub extra_hosts: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tty: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sysctls: Option<SysCtls>,
 }
 
 impl Service {
@@ -357,6 +359,40 @@ pub struct AdvancedNetworkSettings {
     pub ipv4_address: Option<String>,
     pub ipv6_address: Option<String>,
     pub aliases: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum SysCtls {
+    List(Vec<String>),
+    #[cfg(feature = "indexmap")]
+    Map(IndexMap<String, SysCtlValue>),
+    #[cfg(not(feature = "indexmap"))]
+    Map(HashMap<String, SysCtlValue>),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum SysCtlValue {
+    Null,
+    String(String),
+    Bool(bool),
+    Unsigned(u64),
+    Signed(i64),
+    Float(f64),
+}
+
+impl fmt::Display for SysCtlValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Null => f.write_str("null"),
+            Self::String(s) => f.write_str(s),
+            Self::Bool(b) => write!(f, "{b}"),
+            Self::Unsigned(u) => write!(f, "{u}"),
+            Self::Signed(i) => write!(f, "{i}"),
+            Self::Float(fl) => write!(f, "{fl}"),
+        }
+    }
 }
 
 #[cfg(feature = "indexmap")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,8 @@ pub struct Service {
     pub build_: Option<BuildStep>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ports: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Ports::is_empty")]
+    pub ports: Ports,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<Environment>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -196,6 +196,45 @@ pub struct LoggingParameters {
     #[cfg(not(feature = "indexmap"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, SingleValue>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum Ports {
+    Short(Vec<String>),
+    Long(Vec<Port>),
+}
+
+impl Default for Ports {
+    fn default() -> Self {
+        Self::Short(Vec::default())
+    }
+}
+
+impl Ports {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Short(v) => v.is_empty(),
+            Self::Long(v) => v.is_empty(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Port {
+    pub target: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host_ip: Option<String>,
+    pub published: PublishedPort,
+    pub protocol: String,
+    pub mode: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum PublishedPort {
+    Single(u16),
+    Range(String),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
Closes #23. This adds all the properties mentioned in the issue as well as a few others. Additionally, some clean up refactoring was done such as consolidating a few things like labels and removing `Option`s where there is a logical default.

Probably the biggest structural change was adding the `MapOrEmpty` enum to support values that may not exist but shouldn't serialize to `null`. For example, top level networks and volumes are often just a list of keys like so:
```yaml
volumes:
  data:
  db:
```
Before, this was deserialized into a map with values of `Option<ComposeVolume>` meaning they were serialized into:
```yaml
volumes:
  data: null
  db: null
```
Which isn't what we want. Unfortunately, the serde data model doesn't allow for "empty" values so `MapOrEmpty::Empty` serializes into an empty map. Now, volumes deserialize into a map with values of `MapOrEmpty<ComposeVolume>`, which then serializes into:
```yaml
volumes:
  data: {}
  db: {}
```
Which is roughly equivalent to the input.

I also changed the `parse_compose` test a bit to make sure purposefully invalid compose files pass the test if they aren't parsed and fail the test if they are successfully parsed. They are still a few files that don't pass the test, see [my comment](https://github.com/stephanbuys/docker-compose-types/issues/23#issuecomment-1543986451) on the issue.