### PR TITLE
Add secret support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -713,22 +713,18 @@ pub struct UpdateConfig {
 
 #[cfg(feature = "indexmap")]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
-pub struct ComposeSecrets(pub IndexMap<String, Option<ComposeSecret>>);
+pub struct ComposeSecrets(#[serde(with = "serde_yaml::with::singleton_map_recursive")] pub IndexMap<String, Option<ComposeSecret>>);
 #[cfg(not(feature = "indexmap"))]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
-pub struct ComposeSecrets(pub HashMap<String, Option<ComposeSecret>>);
+pub struct ComposeSecrets(#[serde(with = "serde_yaml::with::singleton_map_recursive")] pub HashMap<String, Option<ComposeSecret>>);
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
-#[serde(deny_unknown_fields)]
-pub struct ComposeSecret {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub file: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub environment: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub external: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum ComposeSecret {
+    File(String),
+    Environment(String),
+    #[serde(untagged)]
+    External{external: bool, name: String},
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]

--- a/tests/fixtures/secrets/advanced-secret.yml
+++ b/tests/fixtures/secrets/advanced-secret.yml
@@ -1,0 +1,12 @@
+services:
+  foo:
+    secrets:
+      - source: secret1
+        target: /run/secret/banana
+        uid: "1000"
+        gid: "1000"
+        mode: 0700
+
+secrets:
+  secret1:
+    file: ./foo/bar

--- a/tests/fixtures/secrets/simple-secret.yml
+++ b/tests/fixtures/secrets/simple-secret.yml
@@ -1,0 +1,15 @@
+services:
+  foo:
+    secrets:
+      - secret1
+      - secret2
+      - secret3
+
+secrets:
+  secret1:
+    file: ./foo/bar
+  secret2:
+    environment: FOO_BAR
+  secret3:
+    external: true
+    name: "secret_name"

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -2,6 +2,7 @@
 fn parse_compose() {
     use docker_compose_types::ComposeFile;
     use glob::glob;
+    use std::path::MAIN_SEPARATOR;
 
     let mut all_succeeded = true;
     for entry in glob("tests/fixtures/**/*.yml")
@@ -12,10 +13,10 @@ fn parse_compose() {
         let entry_path = entry.display().to_string();
 
         let skip_list = vec![
-            "v3-full",
-            "extends\\verbose-and-shorthand.yml",
-            "net-container\\v2-invalid.yml",
-            "v2-simple\\links-invalid.yml",
+            format!("v3-full"),
+            format!("extends{MAIN_SEPARATOR}verbose-and-shorthand.yml"),
+            format!("net-container{MAIN_SEPARATOR}v2-invalid.yml"),
+            format!("v2-simple{MAIN_SEPARATOR}links-invalid.yml"),
         ];
 
         if skip_list.iter().any(|s| entry_path.contains(s)) {


### PR DESCRIPTION
Add support for docker secrets, per #28 

Strictly speaking, it should be an error if `external=false` in the top-level secret defintion (as opposed to just not being present) probably... ever, but I don't think it's worth the pain of trying to make it happen.

I also tweaked the tests very slightly so they'll run on both Windows and Unix.