### PR TITLE
Add `cap_drop` and `userns_mode` fields to `Service`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docker-compose-types"
 description = "Deserialization and Serialization of docker-compose.yml files in a relatively strongly typed fashion."
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 repository = "https://github.com/stephanbuys/docker-compose-types"
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,8 @@ pub struct Service {
     pub networks: Networks,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub cap_add: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cap_drop: Vec<String>,
     #[serde(default, skip_serializing_if = "DependsOnOptions::is_empty")]
     pub depends_on: DependsOnOptions,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -119,6 +121,8 @@ pub struct Service {
     pub stop_signal: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub userns_mode: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_dir: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
Closes #32, adds `cap_drop` and `userns_mode` fields to `Service`. Also bumped the major version as this is a breaking change (see https://doc.rust-lang.org/cargo/reference/semver.html#struct-add-public-field-when-no-private).