### PR TITLE
Allow optional driver for LoggingParameters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,8 @@ pub struct DependsCondition {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct LoggingParameters {
-    pub driver: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub driver: Option<String>,
     #[cfg(feature = "indexmap")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<IndexMap<String, SingleValue>>,


### PR DESCRIPTION
The `driver` field for logging parameters is optional in practice and according to the [services spec](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#logging)