### PR TITLE
Add cgroup_parent to Service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docker-compose-types"
 description = "Deserialization and Serialization of docker-compose.yml files in a relatively strongly typed fashion."
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 repository = "https://github.com/stephanbuys/docker-compose-types"
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,8 @@ pub struct Service {
     pub secrets: Option<Secrets>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pull_policy: Option<PullPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cgroup_parent: Option<String>,
 }
 
 impl Service {


### PR DESCRIPTION
This adds cgroup_parent as per https://docs.docker.com/compose/compose-file/05-services/#cgroup_parent.

Thanks very much for this handy little crate!

