### PR TITLE
Support alternative notations for extends

### DIFF
--- a/tests/fixtures/extends/string_type_extend.yml
+++ b/tests/fixtures/extends/string_type_extend.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  myweb:
+    extends: base
+    command: btm
+
+  base:
+    image: busybox
+    command: top


### PR DESCRIPTION
This is a simple implementation to fix  #41. Serde deserialization is not my expertise, so I'm sure there are better way to do this, but at least it seems to work