### PR TITLE
Support read_only containers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,8 @@ pub struct Service {
     pub hostname: Option<String>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub privileged: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub read_only: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub healthcheck: Option<Healthcheck>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/fixtures/read_only/docker-compose.yml
+++ b/tests/fixtures/read_only/docker-compose.yml
@@ -1,0 +1,3 @@
+services:
+  foo:
+    read_only: true


### PR DESCRIPTION
Support for read_only containers:
```yaml
services:
  db:
    image: postgres
    read_only: true
```
reference: https://docs.docker.com/compose/compose-file/05-services/
