### PR TITLE
Add support for gid groups

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ pub struct Service {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_hosts: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub group_add: Vec<String>,
+    pub group_add: Vec<Group>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub tty: bool,
     #[serde(default, skip_serializing_if = "SysCtls::is_empty")]
@@ -950,6 +950,13 @@ impl fmt::Display for SingleValue {
             Self::Float(fl) => write!(f, "{fl}"),
         }
     }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
+#[serde(untagged)]
+pub enum Group {
+    Named(String),
+    Gid(u32),
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash)]

--- a/tests/fixtures/group_add/docker-compose.yml
+++ b/tests/fixtures/group_add/docker-compose.yml
@@ -1,0 +1,6 @@
+service:
+  image: busybox:1.31.0-uclibc
+  user: notauser
+  group_add:
+    - some_group
+    - 1023


### PR DESCRIPTION
Groups can be both Strings and Numerical 
https://docs.docker.com/compose/compose-file/05-services/
```
group_add specifies additional groups, by name or number, which the user inside the container must be a member of.
```

To handle this I have changed the group_add to be an enum of type Group, that can be Named(String) or Gid(u32)
