### PR TITLE
Add support for devices in reservations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -744,13 +744,30 @@ pub enum HealthcheckTest {
     Multiple(Vec<String>),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Limits {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpus: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub devices: Option<Vec<Device>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Device {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub driver: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_ids: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<IndexMap<String, Value>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Default)]
@@ -768,7 +785,7 @@ pub struct Preferences {
     pub spread: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Resources {
     pub limits: Option<Limits>,

--- a/tests/fixtures/devices/docker-compose.yml
+++ b/tests/fixtures/devices/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "2"
+services:
+  simple:
+    image: busybox:1.27.2
+    command: top
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              #device_ids and count is really mutually exclusive
+              #but not in our implementation, that logic must be 
+              #handled on a higher level
+              count: 0 
+              device_ids: ["0"]
+


### PR DESCRIPTION
This add support for devies in reservations as sepcified in
https://docs.docker.com/compose/compose-file/deploy/#devices

Since there is a quite generic "options" field, I set that to a IndexMap<String,Value>. That meant I had to remove Hash on all parents. 