### PR TITLE
Make Compose compatible with output from "docker compose config"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ pub struct SingleService {
 pub struct Compose {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Services::is_empty")]
     pub services: Services,
     #[serde(default, skip_serializing_if = "TopLevelVolumes::is_empty")]
@@ -933,13 +935,15 @@ pub struct AdvancedVolumes {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Bind {
-    pub propagation: String,
+    pub propagation: Option<String>,
+    pub create_host_path: Option<bool>,
+    pub selinux: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Volume {
-    pub nocopy: bool,
+    pub nocopy: Option<bool>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Default)]

--- a/tests/fixtures/volumes/volumes-with-bind.yml
+++ b/tests/fixtures/volumes/volumes-with-bind.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+services:
+  frigate:
+    image: ghcr.io/blakeblackshear/frigate:stable
+    volumes:
+      - type: bind
+        source: /etc/frigate/config.yml
+        target: /config/config.yml
+        bind: 
+          create_host_path: true
+          propagation: shared
+          selinux: z

--- a/tests/fixtures/volumes/volumes-with-empty-volume.yml
+++ b/tests/fixtures/volumes/volumes-with-empty-volume.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+services:
+  frigate:
+    image: ghcr.io/blakeblackshear/frigate:stable
+    volumes:
+      - type: bind
+        source: /etc/frigate/config.yml
+        target: /config/config.yml
+        volume: {}


### PR DESCRIPTION
1. Updated Volume bind filed
  - Made propagation optional, and added additional fields to comply with https://docs.docker.com/reference/compose-file/services/#volumes
2. Allow toplevel field 'name'
  - ref. https://docs.docker.com/reference/compose-file/version-and-name/
3. Handle empty volume fields
  - Make Volume nocopy optional