### PR TITLE
add runtime field to Service struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,8 @@ pub struct Service {
     pub mem_reservation: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mem_swappiness: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<String>,
 }
 
 #[cfg(feature = "indexmap")]

--- a/tests/fixtures/v3-full/docker-compose.yml
+++ b/tests/fixtures/v3-full/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.5"
 services:
   web:
+    runtime: runc
     healthcheck:
       test: cat /etc/passwd
       interval: 10s


### PR DESCRIPTION
Add support for compose file that define a custom container runtime, i.e. nvidia, wasmtime, etc.
https://docs.docker.com/reference/compose-file/services/#runtime