### PR TITLE
Add support for dockerfile_inline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,6 +558,8 @@ pub struct AdvancedBuildStep {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dockerfile: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dockerfile_inline: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub args: Option<BuildArgs>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shm_size: Option<u64>,

--- a/tests/fixtures/dockerfile-inline/docker-compose.yml
+++ b/tests/fixtures/dockerfile-inline/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  busybox:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM busybox
+        RUN ls /


### PR DESCRIPTION
Closes #53 

To support that option is quite straightforward. Since the repo where the fixtures were originally obtained is no longer available, I just crafted one. Also added a specific test for the option. Hope it is OK.