### PR TITLE
add skip_serializing_if for Resources

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -834,7 +834,9 @@ pub struct Preferences {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Resources {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limits: Option<Limits>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reservations: Option<Limits>,
 }
 


### PR DESCRIPTION
Hello
I don't use resources limits in my source docker-compose-example.yml
I got this in output file

```yaml
    deploy:
      resources:
        limits: null
```

I add a fix