### PR TITLE
Stop pinning serde_yaml to an exact version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ norway = ["dep:serde_norway"]
 derive_builder = "0.20.0"
 indexmap = { version = "2.2", features = ["serde"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
-serde_yaml = { version = "=0.9.33", optional = true }
+serde_yaml = { version = "0.9.33", optional = true }
 serde_yml = { version = "0.0.12", optional = true }
 serde_norway = { version = "0.9.42", optional = true }
 


### PR DESCRIPTION
This PR stops pinning `serde_yaml` to an exact version. 

I'd like to use this crate with other crates that use `serde_yaml` at version `0.9.34`; so having this library require an exact version of `serde_yaml` at `0.9.33` is preventing me from being able to use it.

* Prior to this PR, the version semantics for `serde_yaml` were "`serde_yaml` version `0.9.33` exactly is required"
* After this PR, the version semantics for `serde_yaml` are now "Any version of `serde_yaml` that satisfy `0.9.33` <= x < `0.10.0` are OK"