### PR TITLE
Allow Ulimit to accept String in addition to i64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,22 @@ pub enum StringOrList {
     List(Vec<String>),
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
+#[serde(untagged)]
+pub enum StringOrUnsigned {
+    String(String),
+    Unsigned(i64),
+}
+
+impl fmt::Display for StringOrUnsigned {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::String(s) => f.write_str(s),
+            Self::Unsigned(u) => write!(f, "{u}"),
+        }
+    }
+}
+
 #[derive(Builder, Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 #[builder(setter(into), default)]
 pub struct Include {
@@ -572,8 +588,11 @@ impl Ulimits {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(untagged)]
 pub enum Ulimit {
-    Single(i64),
-    SoftHard { soft: i64, hard: i64 },
+    Single(StringOrUnsigned),
+    SoftHard {
+        soft: StringOrUnsigned,
+        hard: StringOrUnsigned,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]

--- a/tests/fixtures/extends/common-env-labels-ulimits.yml
+++ b/tests/fixtures/extends/common-env-labels-ulimits.yml
@@ -9,5 +9,8 @@ web:
   ulimits:
     nproc: 65535
     memlock:
-        soft: 1024
-        hard: 2048
+      soft: 1024
+      hard: 2048
+    nofile:
+      soft: ${ULIMIT_NOFILE}
+      hard: ${ULIMIT_NOFILE}


### PR DESCRIPTION
Currently in main it is only possible to have `ulimits` mappings where the values are signed integers, but it doesn't take into account that the values can be passed as environment variables. This pull request addresses this by making the `Ulimit` type accept either `String` or `i64` rather than just `i64`.

There may be better ways of modeling this as well, but it does solve a problem I'm having where I'm unable to parse a valid docker compose configuration using `ulimits`.