### PR TITLE
Support 'all' in device.count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+## v0.24.0
+
+(Thanks to @mi-prata)
+
+- Allow `deploy.resources.*.devices.count` to be `all` in addition to integers
+  (#66)
+
+(Other)
+
+- Fix feature-matrix test builds without `indexmap` and when multiple YAML
+  backend features are enabled
+
 ## v0.23.0
 
 (Thanks to @8BitMate)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docker-compose-types"
 description = "Deserialization and Serialization of docker-compose.yml files in a relatively strongly typed fashion."
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 repository = "https://github.com/stephanbuys/docker-compose-types"
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,47 @@ impl fmt::Display for StringOrUnsigned {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum DeviceCount {
+    All,
+    Count(u64),
+}
+
+impl Serialize for DeviceCount {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::All => serializer.serialize_str("all"),
+            Self::Count(n) => serializer.serialize_u64(*n),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for DeviceCount {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        if let Some(s) = value.as_str() {
+            if s == "all" {
+                return Ok(Self::All);
+            }
+            return Err(serde::de::Error::custom(
+                format!("invalid device count: {s:?}, expected \"all\" or an integer"),
+            ));
+        }
+        if let Some(n) = value.as_u64() {
+            return Ok(Self::Count(n));
+        }
+        Err(serde::de::Error::custom(
+            "device count must be \"all\" or an integer",
+        ))
+    }
+}
+
 #[derive(Builder, Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 #[builder(setter(into), default)]
 pub struct Include {
@@ -880,7 +921,7 @@ pub struct Device {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub driver: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub count: Option<u32>,
+    pub count: Option<DeviceCount>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,11 @@ use derive_builder::*;
 use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize};
 #[cfg(feature = "norway")]
-use serde_norway as serde_yaml;
-#[cfg(feature = "yml")]
-use serde_yml as serde_yaml;
+use serde_norway as yaml_backend;
+#[cfg(all(feature = "yaml", not(any(feature = "norway", feature = "yml"))))]
+use serde_yaml as yaml_backend;
+#[cfg(all(feature = "yml", not(feature = "norway")))]
+use serde_yml as yaml_backend;
 
 #[cfg(not(feature = "indexmap"))]
 use std::collections::HashMap;
@@ -13,7 +15,7 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
 
-use serde_yaml::Value;
+use yaml_backend::Value;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -120,9 +122,9 @@ impl<'de> Deserialize<'de> for DeviceCount {
             if s == "all" {
                 return Ok(Self::All);
             }
-            return Err(serde::de::Error::custom(
-                format!("invalid device count: {s:?}, expected \"all\" or an integer"),
-            ));
+            return Err(serde::de::Error::custom(format!(
+                "invalid device count: {s:?}, expected \"all\" or an integer"
+            )));
         }
         if let Some(n) = value.as_u64() {
             return Ok(Self::Count(n));
@@ -988,14 +990,14 @@ pub struct UpdateConfig {
 #[cfg(feature = "indexmap")]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ComposeSecrets(
-    #[serde(with = "serde_yaml::with::singleton_map_recursive")]
+    #[serde(with = "yaml_backend::with::singleton_map_recursive")]
     pub  IndexMap<String, Option<ComposeSecret>>,
 );
 
 #[cfg(not(feature = "indexmap"))]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ComposeSecrets(
-    #[serde(with = "serde_yaml::with::singleton_map_recursive")]
+    #[serde(with = "yaml_backend::with::singleton_map_recursive")]
     pub  HashMap<String, Option<ComposeSecret>>,
 );
 

--- a/tests/fixtures/devices/docker-compose.yml
+++ b/tests/fixtures/devices/docker-compose.yml
@@ -10,8 +10,15 @@ services:
             - driver: nvidia
               capabilities: [gpu]
               #device_ids and count is really mutually exclusive
-              #but not in our implementation, that logic must be 
+              #but not in our implementation, that logic must be
               #handled on a higher level
-              count: 0 
+              count: 0
               device_ids: ["0"]
-
+        limits:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              count: all
+            - driver: nvidia
+              capabilities: [gpu]
+              count: 2

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -119,10 +119,12 @@ fn parse_dockerfile_inline() {
 
     let mut actual_parsed: Compose = from_str(&file_payload).unwrap();
 
-    let dockerfile_inline = actual_parsed
-        .services
-        .0
-        .swap_remove("busybox")
+    #[cfg(feature = "indexmap")]
+    let busybox_service = actual_parsed.services.0.swap_remove("busybox");
+    #[cfg(not(feature = "indexmap"))]
+    let busybox_service = actual_parsed.services.0.remove("busybox");
+
+    let dockerfile_inline = busybox_service
         .flatten()
         .and_then(|service| service.build_)
         .map(|build_| match build_ {


### PR DESCRIPTION
"all" is a valid entry for number of selected devices. 

Compose's own document is not very clear, but this is referenced in https://docs.docker.com/reference/compose-file/deploy/#count

I also have compose files running with `count: all` and it works. 

